### PR TITLE
Bug 1027249: Add support for b2g emulator tests

### DIFF
--- a/base/system-setup.sh
+++ b/base/system-setup.sh
@@ -55,15 +55,6 @@ apt-get install -y                  \
   software-properties-common        \
   ;
 
-# Python pip is needed to install virtualenv as used by mozharness later, while
-# this isn't necessary for building I doubt it'll do much harm.
-apt-get install -y                  \
-  python-pip                        \
-  ;
-
-# Install virtualenv for use by mozharness
-pip install virtualenv;
-
 # Install some utilities, we'll be using nodejs in automation scripts, maybe we
 # shouldn't we can clean up later
 apt-get install -y                  \

--- a/builder/build-setup.sh
+++ b/builder/build-setup.sh
@@ -16,4 +16,4 @@ hg clone https://hg.mozilla.org/integration/gaia-central/ /home/worker/gaia
 ### Clean up from setup
 # Remove the setup.sh setup, we don't really need this script anymore, deleting
 # it keeps the image as clean as possible.
-rm $0; echo "Deleted $0";
+# rm $0; echo "Deleted $0";

--- a/tester/Dockerfile
+++ b/tester/Dockerfile
@@ -2,22 +2,18 @@ FROM          registry.taskcluster.net/jonasfj/gecko-base
 MAINTAINER    Jonas Finnemann Jensen <jopsen@gmail.com>
 
 # Add utilities and configuration
-ADD           fetch-artifacts.py        /home/worker/fetch-artifacts.py
-ADD           b2g-desktop-tests.sh      /home/worker/b2g-desktop-tests.sh
-ADD           b2g-desktop-config.py     /home/worker/b2g-desktop-config.py
-ADD           test-setup.sh             /tmp/test-setup.sh
-ADD           dot-config                /home/worker/.config
+ADD           fetch-artifacts.py            /home/worker/fetch-artifacts.py
+ADD           b2g-desktop-tests.sh          /home/worker/b2g-desktop-tests.sh
+ADD           b2g-desktop-config.py         /home/worker/b2g-desktop-config.py
+ADD           test-setup.sh                 /tmp/test-setup.sh
+ADD           dot-config                    /home/worker/.config
+ADD           emulator_automation_config.py /home/worker/emulator_automation_config.py
+
+ENV           DISPLAY         :0
 
 # Run test setup script
-RUN           ["/tmp/test-setup.sh"]
-
-# Install mesa libs
 USER          root
-RUN           apt-get install -y                \
-              libgl1-mesa-dri                   \
-              libglapi-mesa                     \
-              libglu1-mesa                      \
-              ;
+RUN           ["/tmp/test-setup.sh"]
 
 USER          worker
 

--- a/tester/b2g-desktop-tests.sh
+++ b/tester/b2g-desktop-tests.sh
@@ -5,8 +5,6 @@
 ### Check that we are running as worker
 test `whoami` == 'worker';
 
-CONFIG_FILE=/home/worker/desktop_automation_config.py
-
 # Fetch URLs for input binary and test zip file
 #INSTALLER_URL=`./fetch-artifacts.py $TARGET_TASK -u target.linux-x86_64.tar.bz2`;
 #TEST_URL=`./fetch-artifacts.py $TARGET_TASK -u target.tests.zip`;
@@ -17,8 +15,7 @@ INSTALLER_URL=$BUILD_ROOT/b2g-31.0a1.en-US.linux-x86_64.tar.bz2
 TEST_URL=$BUILD_ROOT/b2g-31.0a1.en-US.linux-x86_64.tests.zip
 
 # Run tests for b2g-desktop under xvfb
-xvfb-run -s "-screen 0 800x1000x24" \
-  python ./mozharness/scripts/b2g_desktop_unittest.py \
+python ./mozharness/scripts/b2g_desktop_unittest.py \
   --no-read-buildbot-config \
   --config-file /home/worker/b2g-desktop-config.py \
   --installer-url $INSTALLER_URL \

--- a/tester/emulator_automation_config.py
+++ b/tester/emulator_automation_config.py
@@ -1,0 +1,49 @@
+# This is a template config file for b2g emulator unittest production.
+import os
+
+config = {
+    # mozharness options
+    "application": "b2g",
+    "busybox_url": "http://runtime-binaries.pvt.build.mozilla.org/tooltool/sha512/0748e900821820f1a42e2f1f3fa4d9002ef257c351b9e6b78e7de0ddd0202eace351f440372fbb1ae0b7e69e8361b036f6bd3362df99e67fc585082a311fc0df",
+    "xre_url": "http://runtime-binaries.pvt.build.mozilla.org/tooltool/sha512/263f4e8796c25543f64ba36e53d5c4ab8ed4d4e919226037ac0988761d34791b038ce96a8ae434f0153f9c2061204086decdbff18bdced42f3849156ae4dc9a4",
+    "tooltool_servers": ["http://runtime-binaries.pvt.build.mozilla.org/tooltool/"],
+
+    "exes": {
+        'python': '/usr/bin/python',
+        'tooltool.py': "mozharness/mozharness/mozilla/tooltool.py",
+    },
+
+    "find_links": [
+        "http://pypi.pvt.build.mozilla.org/pub",
+        "http://pypi.pub.build.mozilla.org/pub",
+    ],
+    "pip_index": False,
+
+    "buildbot_json_path": "buildprops.json",
+
+    "default_actions": [
+        'clobber',
+        'read-buildbot-config',
+        'download-and-extract',
+        'create-virtualenv',
+        'install',
+        'run-tests',
+    ],
+    "download_symbols": "ondemand",
+    "download_minidump_stackwalk": True,
+    "default_blob_upload_servers": [
+        "https://blobupload.elasticbeanstalk.com",
+    ],
+    "blob_uploader_auth_file": os.path.join(os.getcwd(), "oauth.txt"),
+
+    "run_file_names": {
+        "jsreftest": "runreftestb2g.py",
+        "mochitest": "runtestsb2g.py",
+        "reftest": "runreftestb2g.py",
+        "crashtest": "runreftestb2g.py",
+        "xpcshell": "runtestsb2g.py"
+    },
+    # test harness options are located in the gecko tree
+    "in_tree_config": "config/mozharness/b2g_emulator_config.py",
+    "vcs_output_timeout": 1760,
+}

--- a/tester/test-setup.sh
+++ b/tester/test-setup.sh
@@ -2,11 +2,24 @@
 
 ### Firefox Test Setup
 
-# directories for devicestorage
+dpkg --add-architecture i386
+apt-get update
+apt-get install -y                \
+        gcc-multilib              \
+        g++-multilib              \
+        libgl1-mesa-dri           \
+        libgl1-mesa-glx:i386      \
+        libglapi-mesa             \
+        libglu1-mesa              \
+        libncurses5:i386          \
+        libsdl1.2debian:i386      \
+        python-pip                \
+        ;
+pip install virtualenv;
 mkdir Documents; mkdir Pictures; mkdir Music; mkdir Videos;
-
-# Install mozharness scripts
 hg clone http://hg.mozilla.org/build/mozharness/
+echo 'Xvfb :0 -nolisten tcp -screen 0 1600x1200x24 &> /dev/null &' >> .bashrc
+chown -R worker:worker /home/worker/* /home/worker/.*
 
 ### Clean up from setup
 # Remove the setup.sh setup, we don't really need this script anymore, deleting


### PR DESCRIPTION
These are the changes I needed to run b2g emulator tests: Install various extra packages and run Xvfb in the background instead of xvfb-run. This time gecko-tester just runs test-setup.sh and all the work is done in that script.
