### PR TITLE
Bug 1046815: Update mozharness configs

### DIFF
--- a/tester/b2g-desktop-config.py
+++ b/tester/b2g-desktop-config.py
@@ -4,11 +4,14 @@ import os
 config = {
     # mozharness options
     "application": "b2g",
+    "tooltool_servers": ["http://runtime-binaries.pvt.build.mozilla.org/tooltool/"],
 
     "find_links": [
+        "http://pypi.pvt.build.mozilla.org/pub",
         "http://pypi.pub.build.mozilla.org/pub",
     ],
     "pip_index": False,
+    "buildbot_json_path": "buildprops.json",
 
     "default_actions": [
         'clobber',
@@ -20,10 +23,16 @@ config = {
     ],
     "download_symbols": "ondemand",
     "download_minidump_stackwalk": True,
+    "default_blob_upload_servers": [
+        "https://blobupload.elasticbeanstalk.com",
+    ],
+    "blob_uploader_auth_file": os.path.join(os.getcwd(), "oauth.txt"),
 
+    # testsuite options
     "run_file_names": {
         "mochitest": "runtestsb2g.py",
         "reftest": "runreftestb2g.py",
     },
-   "in_tree_config": "config/mozharness/b2g_desktop_config.py",
+    # test harness options are located in the gecko tree
+    "in_tree_config": "config/mozharness/b2g_desktop_config.py",
 }

--- a/tester/emulator_automation_config.py
+++ b/tester/emulator_automation_config.py
@@ -41,7 +41,8 @@ config = {
         "mochitest": "runtestsb2g.py",
         "reftest": "runreftestb2g.py",
         "crashtest": "runreftestb2g.py",
-        "xpcshell": "runtestsb2g.py"
+        "xpcshell": "runtestsb2g.py",
+        "cppunittest": "remotecppunittests.py"
     },
     # test harness options are located in the gecko tree
     "in_tree_config": "config/mozharness/b2g_emulator_config.py",


### PR DESCRIPTION
This almost re-syncs our mozharness config files with the "real" ones in mozharness. The remaining differences are a few references to /tools; I am trying to sort out those differences with Release Engineering, but that may take some time.
